### PR TITLE
fix: `ICTSC2022 問題解説まとめ` から `ICTSC2019 本選 問題解説まとめ` までのリンクを WordPress 側に寄せた

### DIFF
--- a/src/content/blog/wordpress/2020030116003099.md
+++ b/src/content/blog/wordpress/2020030116003099.md
@@ -3,7 +3,7 @@ title: "VPNが繋がらない"
 description: "VPNが繋がらない"
 tags: [ICTSC2019,問題解説]
 pubDate: 2020-03-01T16:00:27
-slug: "2020/03/01/VPNが繋がらない"
+slug: "2020/03/01/vpnが繋がらない"
 draft: false
 renderer: "html"
 sticky: false

--- a/src/content/blog/wordpress/2020030116003108.md
+++ b/src/content/blog/wordpress/2020030116003108.md
@@ -3,7 +3,7 @@ title: "適当に俳句投稿サービス作ったらXSRF脆弱性孕んでた�
 description: "適当に俳句投稿サービス作ったらXSRF脆弱性孕んでた件。"
 tags: [ICTSC2019,問題解説]
 pubDate: 2020-03-01T16:00:00
-slug: "2020/03/01/適当に俳句投稿サービス作ったらXSRF脆弱性孕んでた件。"
+slug: "2020/03/01/適当に俳句投稿サービス作ったらxsrf脆弱性孕んでた件。"
 draft: false
 renderer: "html"
 sticky: false

--- a/src/content/blog/wordpress/2020030116003116.md
+++ b/src/content/blog/wordpress/2020030116003116.md
@@ -3,7 +3,7 @@ title: "TORACON_QUEST ~そして障害へ~"
 description: "TORACON_QUEST ~そして障害へ~"
 tags: [ICTSC2019,問題解説]
 pubDate: 2020-03-01T16:00:00
-slug: "2020/03/01/TORACON_QUEST ~そして障害へ~"
+slug: "2020/03/01/oracon_quest-そして障害へ"
 draft: false
 renderer: "html"
 sticky: false

--- a/src/content/blog/wordpress/2020030116003120.md
+++ b/src/content/blog/wordpress/2020030116003120.md
@@ -3,7 +3,7 @@ title: "生き返れMariaDB"
 description: "生き返れMariaDB"
 tags: [ICTSC2019,問題解説]
 pubDate: 2020-03-01T16:00:00
-slug: "2020/03/01/生き返れMariaDB"
+slug: "2020/03/01/生き返れmariadb"
 draft: false
 renderer: "html"
 sticky: false

--- a/src/content/blog/wordpress/2020030116003127.md
+++ b/src/content/blog/wordpress/2020030116003127.md
@@ -3,7 +3,7 @@ title: "DM-VPNをつなげてください"
 description: "DM-VPNをつなげてください"
 tags: [ICTSC2019,問題解説]
 pubDate: 2020-03-01T16:00:00
-slug: "2020/03/01/DM-VPNをつなげてください"
+slug: "2020/03/01/dm-vpnをつなげてください"
 draft: false
 renderer: "html"
 sticky: false

--- a/src/content/blog/wordpress/2020030116003134.md
+++ b/src/content/blog/wordpress/2020030116003134.md
@@ -3,7 +3,7 @@ title: "IPアドレスが割り当てられない！"
 description: "IPアドレスが割り当てられない！"
 tags: [ICTSC2019,問題解説]
 pubDate: 2020-03-01T16:00:00
-slug: "2020/03/01/IPアドレスが割り当てられない！"
+slug: "2020/03/01/ipアドレスが割り当てられない！"
 draft: false
 renderer: "html"
 sticky: false

--- a/src/content/blog/wordpress/2020030118383148.md
+++ b/src/content/blog/wordpress/2020030118383148.md
@@ -3,7 +3,7 @@ title: "SSHできなくなっちゃった2"
 description: "SSHできなくなっちゃった2"
 tags: [ICTSC2019,問題解説]
 pubDate: 2020-03-01T18:38:49
-slug: "2020/03/01/SSHできなくなっちゃった2"
+slug: "2020/03/01/sshできなくなっちゃった2"
 draft: false
 renderer: "html"
 sticky: false

--- a/src/content/blog/wordpress/2020110217023190.md
+++ b/src/content/blog/wordpress/2020110217023190.md
@@ -3,7 +3,7 @@ title: "WEBページが見れない"
 description: "WEBページが見れない"
 tags: [ICTSC2020,問題解説]
 pubDate: 2020-11-02T17:02:43
-slug: "2020/11/02/WEBページが見れない"
+slug: "2020/11/02/webページが見れない"
 draft: false
 renderer: "html"
 sticky: false

--- a/src/content/blog/wordpress/2020110217023201.md
+++ b/src/content/blog/wordpress/2020110217023201.md
@@ -3,7 +3,7 @@ title: "またビルド失敗しちゃった～…"
 description: "またビルド失敗しちゃった～…"
 tags: [ICTSC2020,問題解説]
 pubDate: 2020-11-02T17:02:06
-slug: "2020/11/02/またビルド失敗しちゃった～…"
+slug: "2020/11/02/またビルド失敗しちゃった～"
 draft: false
 renderer: "html"
 sticky: false

--- a/src/content/blog/wordpress/2021031517303275.md
+++ b/src/content/blog/wordpress/2021031517303275.md
@@ -3,7 +3,7 @@ title: "部署を統合したが…"
 description: "部署を統合したが…"
 tags: [ICTSC2020,問題解説]
 pubDate: 2021-03-15T17:30:59
-slug: "2021/03/15/部署を統合したが…"
+slug: "2021/03/15/部署を統合したが"
 draft: false
 renderer: "html"
 sticky: false

--- a/src/content/blog/wordpress/2021031611113288.md
+++ b/src/content/blog/wordpress/2021031611113288.md
@@ -3,7 +3,7 @@ title: "Webサーバーに繋がらない！"
 description: "Webサーバーに繋がらない！"
 tags: [ICTSC2020,問題解説]
 pubDate: 2021-03-16T11:11:18
-slug: "2021/03/16/Webサーバーに繋がらない！"
+slug: "2021/03/16/webサーバーに繋がらない！"
 draft: false
 renderer: "html"
 sticky: false

--- a/src/content/blog/wordpress/2021031611363281.md
+++ b/src/content/blog/wordpress/2021031611363281.md
@@ -3,7 +3,7 @@ title: "DNSサーバを作りたかったらしい"
 description: "DNSサーバを作りたかったらしい"
 tags: [ICTSC2020,問題解説]
 pubDate: 2021-03-16T11:36:30
-slug: "2021/03/16/DNSサーバを作りたかったらしい"
+slug: "2021/03/16/dnsサーバを作りたかったらしい"
 draft: false
 renderer: "html"
 sticky: false

--- a/src/content/blog/wordpress/2021031611363283.md
+++ b/src/content/blog/wordpress/2021031611363283.md
@@ -3,7 +3,7 @@ title: "FTPなんもわからん"
 description: "FTPなんもわからん"
 tags: [ICTSC2020,問題解説]
 pubDate: 2021-03-16T11:36:30
-slug: "2021/03/16/FTPなんもわからん"
+slug: "2021/03/16/ftpなんもわからん"
 draft: false
 renderer: "html"
 sticky: false

--- a/src/content/blog/wordpress/2021031611363290.md
+++ b/src/content/blog/wordpress/2021031611363290.md
@@ -3,7 +3,7 @@ title: "Nginxが展開できない"
 description: "Nginxが展開できない"
 tags: [ICTSC2020,問題解説]
 pubDate: 2021-03-16T11:36:30
-slug: "2021/03/16/Nginxが展開できない"
+slug: "2021/03/16/nginxが展開できない"
 draft: false
 renderer: "html"
 sticky: false

--- a/src/content/blog/wordpress/2021031611363298.md
+++ b/src/content/blog/wordpress/2021031611363298.md
@@ -3,7 +3,7 @@ title: "FTPが壊れちゃった！"
 description: "FTPが壊れちゃった！"
 tags: [ICTSC2020,問題解説]
 pubDate: 2021-03-16T11:36:29
-slug: "2021/03/16/FTPが壊れちゃった！"
+slug: "2021/03/16/ftpが壊れちゃった！"
 draft: false
 renderer: "html"
 sticky: false

--- a/src/content/blog/wordpress/2021031611363300.md
+++ b/src/content/blog/wordpress/2021031611363300.md
@@ -3,7 +3,7 @@ title: "続・このOpenStackなんか変だよぉ…"
 description: "続・このOpenStackなんか変だよぉ…"
 tags: [ICTSC2020,問題解説]
 pubDate: 2021-03-16T11:36:29
-slug: "2021/03/16/続・このOpenStackなんか変だよぉ…"
+slug: "2021/03/16/続・このopenstackなんか変だよぉ…"
 draft: false
 renderer: "html"
 sticky: false

--- a/src/content/blog/wordpress/2021031611363302.md
+++ b/src/content/blog/wordpress/2021031611363302.md
@@ -3,7 +3,7 @@ title: "このOpenStackなんか変だよぉ…"
 description: "このOpenStackなんか変だよぉ…"
 tags: [ICTSC2020,問題解説]
 pubDate: 2021-03-16T11:36:29
-slug: "2021/03/16/このOpenStackなんか変だよぉ…"
+slug: "2021/03/16/このopenstackなんか変だよぉ…"
 draft: false
 renderer: "html"
 sticky: false

--- a/src/content/blog/wordpress/2021031611363306.md
+++ b/src/content/blog/wordpress/2021031611363306.md
@@ -3,7 +3,7 @@ title: "ボク わるいフレームワークじゃないよ"
 description: "ボク わるいフレームワークじゃないよ"
 tags: [ICTSC2020,問題解説]
 pubDate: 2021-03-16T11:36:29
-slug: "2021/03/16/ボク わるいフレームワークじゃないよ"
+slug: "2021/03/16/ボク-わるいフレームワークじゃないよ"
 draft: false
 renderer: "html"
 sticky: false

--- a/src/content/blog/wordpress/2021031611363310.md
+++ b/src/content/blog/wordpress/2021031611363310.md
@@ -3,7 +3,7 @@ title: "GREが繋がらない!"
 description: "GREが繋がらない!"
 tags: [ICTSC2020,問題解説]
 pubDate: 2021-03-16T11:36:29
-slug: "2021/03/16/GREが繋がらない!"
+slug: "2021/03/16/greが繋がらない!"
 draft: false
 renderer: "html"
 sticky: false

--- a/src/content/blog/wordpress/2021031611363312.md
+++ b/src/content/blog/wordpress/2021031611363312.md
@@ -3,7 +3,7 @@ title: "Server Sent Eventsが動作しない‼"
 description: "Server Sent Eventsが動作しない‼"
 tags: [ICTSC2020,問題解説]
 pubDate: 2021-03-16T11:36:29
-slug: "2021/03/16/Server Sent Eventsが動作しない‼"
+slug: "2021/03/16/server-sent-eventsが動作しない‼"
 draft: false
 renderer: "html"
 sticky: false

--- a/src/content/blog/wordpress/2021031611373252.md
+++ b/src/content/blog/wordpress/2021031611373252.md
@@ -3,7 +3,7 @@ title: "証明書の取得ができない!!"
 description: "証明書の取得ができない!!"
 tags: [ICTSC2020,問題解説]
 pubDate: 2021-03-16T11:37:06
-slug: "2021/03/16/証明書の取得ができない!!"
+slug: "2021/03/16/証明書の取得ができない"
 draft: false
 renderer: "html"
 sticky: false

--- a/src/content/blog/wordpress/2021090210593378.md
+++ b/src/content/blog/wordpress/2021090210593378.md
@@ -3,7 +3,7 @@ title: "クラウドネイティブは難しい…"
 description: "クラウドネイティブは難しい…"
 tags: [ICTSC2021,未分類]
 pubDate: 2021-09-02T10:59:13
-slug: "2021/09/02/クラウドネイティブは難しい…"
+slug: "2021/09/02/クラウドネイティブは難しい"
 draft: false
 renderer: "html"
 sticky: false

--- a/src/content/blog/wordpress/2021090315053381.md
+++ b/src/content/blog/wordpress/2021090315053381.md
@@ -3,7 +3,7 @@ title: "頑固なindex.html"
 description: "頑固なindex.html"
 tags: [ICTSC2021,未分類]
 pubDate: 2021-09-03T15:05:02
-slug: "2021/09/03/頑固なindex.html"
+slug: "2021/09/03/頑固なindex-html"
 draft: false
 renderer: "html"
 sticky: false

--- a/src/content/blog/wordpress/2021090315133400.md
+++ b/src/content/blog/wordpress/2021090315133400.md
@@ -3,7 +3,7 @@ title: "iscsi targetにログインできない!"
 description: "iscsi targetにログインできない!"
 tags: [ICTSC2021]
 pubDate: 2021-09-03T15:13:50
-slug: "2021/09/03/iscsi targetにログインできない!"
+slug: "2021/09/03/iscsi targetにログインできない"
 draft: false
 renderer: "html"
 sticky: false

--- a/src/content/blog/wordpress/2021090315213408.md
+++ b/src/content/blog/wordpress/2021090315213408.md
@@ -3,7 +3,7 @@ title: "dockerをインストールしただけなのに..."
 description: "dockerをインストールしただけなのに&#8230;"
 tags: [ICTSC2021]
 pubDate: 2021-09-03T15:21:08
-slug: "2021/09/03/dockerをインストールしただけなのに..."
+slug: "2021/09/03/dockerをインストールしただけなのに"
 draft: false
 renderer: "html"
 sticky: false

--- a/src/content/blog/wordpress/2021090315253416.md
+++ b/src/content/blog/wordpress/2021090315253416.md
@@ -3,7 +3,7 @@ title: "Webサイトにアクセスできない"
 description: "Webサイトにアクセスできない"
 tags: [ICTSC2021]
 pubDate: 2021-09-03T15:25:32
-slug: "2021/09/03/Webサイトにアクセスできない"
+slug: "2021/09/03/webサイトにアクセスできない"
 draft: false
 renderer: "html"
 sticky: false

--- a/src/content/blog/wordpress/2021090315313422.md
+++ b/src/content/blog/wordpress/2021090315313422.md
@@ -3,7 +3,7 @@ title: "Webサーバが立ち上がらない"
 description: "Webサーバが立ち上がらない"
 tags: [ICTSC2021]
 pubDate: 2021-09-03T15:31:04
-slug: "2021/09/03/Webサーバが立ち上がらない"
+slug: "2021/09/03/webサーバが立ち上がらない"
 draft: false
 renderer: "html"
 sticky: false

--- a/src/content/blog/wordpress/2021090315333426.md
+++ b/src/content/blog/wordpress/2021090315333426.md
@@ -3,7 +3,7 @@ title: "L or R?"
 description: "L or R?"
 tags: [ICTSC2021]
 pubDate: 2021-09-03T15:33:48
-slug: "2021/09/03/L or R"
+slug: "2021/09/03/l-or-r"
 draft: false
 renderer: "html"
 sticky: false


### PR DESCRIPTION
関連 #5

## XX

* `ICTSC2019 二次予選 問題解説まとめ` 以前は別途
* restyled の空白修正が多くなってるので差分で見ていただけると🙏